### PR TITLE
Robustify platform support

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -4,3 +4,11 @@ driver:
 
 platforms:
   - name: macosx
+    driver:
+      name: localhost
+
+suites:
+  - name: mac_direct_download
+    run_list:
+      - recipe[divvy_test::mac_direct_download]
+    attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,3 +21,7 @@ suites:
       mac_app_store:
         username: <%= ENV['APPLE_ID_USERNAME'] %>
         password: <%= ENV['APPLE_ID_PASSWORD'] %>
+  - name: mac_direct_download
+    run_list:
+      - recipe[divvy_test::mac_direct_download]
+    attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,12 +6,15 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: macosx
+  - name: macosx-10.10
     driver:
-      box: roboticcheese/macosx
+      box: roboticcheese/macosx-10.10
       ssh:
         insert_key: false
       gui: true
+  - name: windows-2012
+    driver:
+      box: roboticcheese/windows-2012
 
 suites:
   - name: default
@@ -25,3 +28,5 @@ suites:
     run_list:
       - recipe[divvy_test::mac_direct_download]
     attributes:
+    excludes:
+      - windows-2012

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - cp .kitchen.travis.yml .kitchen.local.yml
 
 script:
-  - chef exec rake
+  - chef exec rake && chef exec rake kitchen:all
 
 after_script:
 

--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,5 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'divvy_test', path: 'test/fixtures/cookbooks/divvy_test'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Divvy Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Add support for non-App Store direct downloads for OS X
+- Add support for Windows
 
 v0.1.0 (2015-04-25)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v?.?.? (????-??-??)
 - Add support for non-App Store direct downloads for OS X
 - Add support for Windows
 - Grant required Accessibility privileges automatically on OS X
+- Add a `:run` action and start Divvy after it's installed
 
 v0.1.0 (2015-04-25)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v?.?.? (????-??-??)
 -------------------
 - Add support for non-App Store direct downloads for OS X
 - Add support for Windows
+- Grant required Accessibility privileges automatically on OS X
 
 v0.1.0 (2015-04-25)
 -------------------

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test do
   gem 'test-kitchen'
   gem 'kitchen-localhost'
   gem 'kitchen-vagrant'
+  gem 'winrm-transport'
 end
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ Syntax:
 
 Actions:
 
-| Action     | Description               |
-|------------|---------------------------|
-| `:install` | Install the app (default) |
-| `:run`     | Run the app (default)     |
+| Action     | Description     |
+|------------|-----------------|
+| `:install` | Install the app |
+| `:run`     | Run the app     |
 
 Attributes:
 
-| Attribute  | Default        | Description          |
-|------------|----------------|----------------------|
-| action     | `:install`     | Action(s) to perform |
+| Attribute  | Default            | Description          |
+|------------|--------------------|----------------------|
+| action     | `[:install, :run]` | Action(s) to perform |
 
 Providers
 =========

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Attributes:
 |------------|----------------|----------------------|
 | action     | `:install`     | Action(s) to perform |
 
+Providers
+=========
+
+***Chef::Provider::DivvyApp::MacOsX::AppStore***
+
+Provider for installing Divvy from the Mac App Store (default for OS X).
+
+***Chef::Provider::DivvyApp::MacOsX::Direct***
+
+Provider to do a direct download and install from the vendor's site. 
+
 Contributing
 ============
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Recipes
 
 ***default***
 
-Opens the Mac App Store and performs a simple install of the app.
+Installs Divvy (from the Mac App Store or a Windows direct download by
+default) and starts it.
 
 Resources
 =========
@@ -44,14 +45,15 @@ Used to perform installation of the app.
 Syntax:
 
     divvy_app 'default' do
-        action :install
+        action [:install, :run]
     end
 
 Actions:
 
-| Action     | Description     |
-|------------|-----------------|
-| `:install` | Install the app |
+| Action     | Description               |
+|------------|---------------------------|
+| `:install` | Install the app (default) |
+| `:run`     | Run the app (default)     |
 
 Attributes:
 
@@ -68,7 +70,12 @@ Provider for installing Divvy from the Mac App Store (default for OS X).
 
 ***Chef::Provider::DivvyApp::MacOsX::Direct***
 
-Provider to do a direct download and install from the vendor's site. 
+Provider to do a direct download and install for OS X from the vendor's site. 
+
+***Chef::Provider::DivvyApp::Windows***
+
+Provider to do a direct download and install from the vendor's site (default
+for Windows).
 
 Contributing
 ============

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -21,7 +21,9 @@
 if defined?(ChefSpec)
   ChefSpec.define_matcher(:divvy_app)
 
-  def install_divvy_app(name)
-    ChefSpec::Matchers::ResourceMatcher.new(:divvy_app, :install, name)
+  [:install, :run].each do |a|
+    define_method("#{a}_divvy_app") do |name|
+      ChefSpec::Matchers::ResourceMatcher.new(:divvy_app, a, name)
+    end
   end
 end

--- a/libraries/provider_divvy_app.rb
+++ b/libraries/provider_divvy_app.rb
@@ -21,6 +21,7 @@
 require 'chef/provider/lwrp_base'
 require_relative 'resource_divvy_app'
 require_relative 'provider_divvy_app_mac_os_x'
+require_relative 'provider_divvy_app_windows'
 
 class Chef
   class Provider

--- a/libraries/provider_divvy_app.rb
+++ b/libraries/provider_divvy_app.rb
@@ -46,6 +46,9 @@ class Chef
       action :install do
         install!
         new_resource.installed(true)
+        Chef::Log.info(
+          'If you have a Divvy license, don\'t forget to enter it in the app!'
+        )
       end
 
       private

--- a/libraries/provider_divvy_app.rb
+++ b/libraries/provider_divvy_app.rb
@@ -51,7 +51,26 @@ class Chef
         )
       end
 
+      #
+      # Start the app.
+      #
+      action :run do
+        start!
+        new_resource.running(true)
+      end
+
       private
+
+      #
+      # Start the Divvy app running using whatever command is appropriate for
+      # the current platform.
+      #
+      # @raise [NotImplementedError] if not defined for this provider.
+      #
+      def start!
+        fail(NotImplementedError,
+             "`start` method not implemented for #{self.class} provider")
+      end
 
       #
       # Do the actual app installation.

--- a/libraries/provider_divvy_app_mac_os_x.rb
+++ b/libraries/provider_divvy_app_mac_os_x.rb
@@ -21,6 +21,7 @@
 require 'chef/provider/lwrp_base'
 require_relative 'provider_divvy_app'
 require_relative 'provider_divvy_app_mac_os_x_app_store'
+require_relative 'provider_divvy_app_mac_os_x_direct'
 
 class Chef
   class Provider

--- a/libraries/provider_divvy_app_mac_os_x.rb
+++ b/libraries/provider_divvy_app_mac_os_x.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+require 'etc'
 require 'chef/provider/lwrp_base'
 require_relative 'provider_divvy_app'
 require_relative 'provider_divvy_app_mac_os_x_app_store'
@@ -30,7 +31,25 @@ class Chef
       #
       # @author Jonathan Hartman <j@p4nt5.com>
       class MacOsX < DivvyApp
+        # `URL` varies by sub-provider
+        PATH ||= '/Applications/Divvy.app'
+
         private
+
+        #
+        # (see DivvyApp#start!)
+        #
+        def start!
+          execute 'start divvy' do
+            command "open #{PATH}"
+            user Etc.getlogin
+            action :run
+            only_if do
+              cmd = 'ps -A -c -o command | grep ^Divvy$'
+              Mixlib::ShellOut.new(cmd).run_command.stdout.empty?
+            end
+          end
+        end
 
         #
         # Authorize the Divvy app.

--- a/libraries/provider_divvy_app_mac_os_x.rb
+++ b/libraries/provider_divvy_app_mac_os_x.rb
@@ -30,6 +30,37 @@ class Chef
       #
       # @author Jonathan Hartman <j@p4nt5.com>
       class MacOsX < DivvyApp
+        private
+
+        #
+        # Authorize the Divvy app.
+        #
+        # (see DivvyApp#install!)
+        #
+        def install!
+          authorize_app!
+        end
+
+        #
+        # Declare a trusted_app resource and grant Accessibility to the app.
+        #
+        def authorize_app!
+          mac_app_store_trusted_app app_id do
+            action :create
+          end
+        end
+
+        #
+        # Return the ID the Accessibility database needs for this provider.
+        #
+        # @return [String]
+        #
+        # @raise [NotImplementedError] if not overloaded for this provider
+        #
+        def app_id
+          fail(NotImplementedError,
+               "`app_id` method not implemented for #{self.class} provider")
+        end
       end
     end
   end

--- a/libraries/provider_divvy_app_mac_os_x_app_store.rb
+++ b/libraries/provider_divvy_app_mac_os_x_app_store.rb
@@ -40,6 +40,14 @@ class Chef
               bundle_id 'com.mizage.divvy'
               action :install
             end
+            super
+          end
+
+          #
+          # (see MacOsX#app_id)
+          #
+          def app_id
+            'com.mizage.Divvy'
           end
         end
       end

--- a/libraries/provider_divvy_app_mac_os_x_direct.rb
+++ b/libraries/provider_divvy_app_mac_os_x_direct.rb
@@ -38,12 +38,27 @@ class Chef
           # (see DivvyApp#install!)
           #
           def install!
+            execute_resource
+            remote_file_resource
+            super
+          end
+
+          #
+          # Declare an execute resource for extracting the downloaded file.
+          #
+          def execute_resource
             path = download_path
             execute 'unzip divvy' do
               command "unzip -d /Applications #{path}"
               action :nothing
             end
-            remote_file path do
+          end
+
+          #
+          # Declare a remote_file resource for downloading the file.
+          #
+          def remote_file_resource
+            remote_file download_path do
               source URL
               action :create
               notifies :run, 'execute[unzip divvy]'
@@ -57,6 +72,13 @@ class Chef
           #
           def download_path
             ::File.join(Chef::Config[:file_cache_path], ::File.basename(URL))
+          end
+
+          #
+          # (see MacOsx#app_id)
+          #
+          def app_id
+            'com.mizage.direct.Divvy'
           end
         end
       end

--- a/libraries/provider_divvy_app_mac_os_x_direct.rb
+++ b/libraries/provider_divvy_app_mac_os_x_direct.rb
@@ -50,7 +50,8 @@ class Chef
             path = download_path
             execute 'unzip divvy' do
               command "unzip -d /Applications #{path}"
-              action :nothing
+              action :run
+              creates PATH
             end
           end
 
@@ -61,7 +62,7 @@ class Chef
             remote_file download_path do
               source URL
               action :create
-              notifies :run, 'execute[unzip divvy]'
+              only_if { !::File.exist?(PATH) }
             end
           end
 

--- a/libraries/provider_divvy_app_mac_os_x_direct.rb
+++ b/libraries/provider_divvy_app_mac_os_x_direct.rb
@@ -1,0 +1,65 @@
+# Encoding: UTF-8
+#
+# Cookbook Name:: divvy
+# Library:: provider_divvy_app_mac_os_x_direct
+#
+# Copyright 2015 Jonathan Hartman
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider/lwrp_base'
+require_relative 'provider_divvy_app'
+require_relative 'provider_divvy_app_mac_os_x'
+
+class Chef
+  class Provider
+    class DivvyApp < Provider::LWRPBase
+      class MacOsX < DivvyApp
+        # A Chef provider for OS X installs via direct download.
+        #
+        # @author Jonathan Hartman <j@p4nt5.com>
+        class Direct < MacOsX
+          URL ||= 'http://mizage.com/downloads/Divvy.zip'
+
+          private
+
+          #
+          # (see DivvyApp#install!)
+          #
+          def install!
+            path = download_path
+            execute 'unzip divvy' do
+              command "unzip -d /Applications #{path}"
+              action :nothing
+            end
+            remote_file path do
+              source URL
+              action :create
+              notifies :run, 'execute[unzip divvy]'
+            end
+          end
+
+          #
+          # Construct a path to download the app file to.
+          #
+          # @return [String]
+          #
+          def download_path
+            ::File.join(Chef::Config[:file_cache_path], ::File.basename(URL))
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/provider_divvy_app_mac_os_x_direct.rb
+++ b/libraries/provider_divvy_app_mac_os_x_direct.rb
@@ -38,15 +38,15 @@ class Chef
           # (see DivvyApp#install!)
           #
           def install!
-            remote_file_resource
-            execute_resource
+            download_package
+            install_package
             super
           end
 
           #
           # Declare a remote_file resource for downloading the file.
           #
-          def remote_file_resource
+          def download_package
             remote_file download_path do
               source URL
               action :create
@@ -57,7 +57,7 @@ class Chef
           #
           # Declare an execute resource for extracting the downloaded file.
           #
-          def execute_resource
+          def install_package
             path = download_path
             execute 'unzip divvy' do
               command "unzip -d /Applications #{path}"

--- a/libraries/provider_divvy_app_mac_os_x_direct.rb
+++ b/libraries/provider_divvy_app_mac_os_x_direct.rb
@@ -38,9 +38,20 @@ class Chef
           # (see DivvyApp#install!)
           #
           def install!
-            execute_resource
             remote_file_resource
+            execute_resource
             super
+          end
+
+          #
+          # Declare a remote_file resource for downloading the file.
+          #
+          def remote_file_resource
+            remote_file download_path do
+              source URL
+              action :create
+              only_if { !::File.exist?(PATH) }
+            end
           end
 
           #
@@ -52,17 +63,6 @@ class Chef
               command "unzip -d /Applications #{path}"
               action :run
               creates PATH
-            end
-          end
-
-          #
-          # Declare a remote_file resource for downloading the file.
-          #
-          def remote_file_resource
-            remote_file download_path do
-              source URL
-              action :create
-              only_if { !::File.exist?(PATH) }
             end
           end
 

--- a/libraries/provider_divvy_app_windows.rb
+++ b/libraries/provider_divvy_app_windows.rb
@@ -33,6 +33,9 @@ class Chef
 
         private
 
+        #
+        # (see DivvyApp#start!)
+        #
         def start!
           exe = ::File.join(PATH, 'Divvy.exe')
           execute 'run divvy' do
@@ -46,11 +49,17 @@ class Chef
           end
         end
 
+        #
+        # (see DivvyApp#install!)
+        #
         def install!
           download_package
           install_package
         end
 
+        #
+        # Download the package file from the remote URL.
+        #
         def download_package
           path = download_path
           remote_file path do
@@ -60,6 +69,9 @@ class Chef
           end
         end
 
+        #
+        # Install the package we just downloaded.
+        #
         def install_package
           path = download_path
           windows_package 'Divvy' do

--- a/libraries/provider_divvy_app_windows.rb
+++ b/libraries/provider_divvy_app_windows.rb
@@ -1,0 +1,59 @@
+# Encoding: UTF-8
+#
+# Cookbook Name:: divvy
+# Library:: provider_divvy_app_windows
+#
+# Copyright 2015 Jonathan Hartman
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider/lwrp_base'
+require_relative 'provider_divvy_app'
+
+class Chef
+  class Provider
+    class DivvyApp < Provider::LWRPBase
+      # An empty parent class for the Divvy for OS X providers.
+      #
+      # @author Jonathan Hartman <j@p4nt5.com>
+      class Windows < DivvyApp
+        URL ||= 'http://mizage.com/downloads/InstallDivvy.exe'
+
+        private
+
+        def install!
+          path = download_path
+          remote_file path do
+            source URL
+            action :create
+          end
+          windows_package 'Divvy' do
+            source path
+            installer_type :nsis
+            action :install
+          end
+        end
+
+        #
+        # Construct a path to download the app file to.
+        #
+        # @return [String]
+        #
+        def download_path
+          ::File.join(Chef::Config[:file_cache_path], ::File.basename(URL))
+        end
+      end
+    end
+  end
+end

--- a/libraries/provider_divvy_app_windows.rb
+++ b/libraries/provider_divvy_app_windows.rb
@@ -29,8 +29,26 @@ class Chef
       # @author Jonathan Hartman <j@p4nt5.com>
       class Windows < DivvyApp
         URL ||= 'http://mizage.com/downloads/InstallDivvy.exe'
+        PATH ||= ::File.expand_path('~/AppData/Local/Mizage LLC/Divvy')
 
         private
+
+        def start!
+          exe = ::File.join(PATH, 'Divvy.exe')
+          execute 'run divvy' do
+            # TODO: This command succeeds when Chef is run locally, but Divvy
+            # exits immediately when run remotely from Test Kitchen. Probably
+            # something related to Windows session management that I'll need to
+            # learn more about. :(
+            command "powershell -c \"Start-Process '#{exe}'\""
+            action :run
+            only_if do
+              cmd = 'Get-Process Divvy -ErrorAction SilentlyContinue'
+              Mixlib::ShellOut.new("powershell -c \"#{cmd}\"").run_command
+                .stdout.empty?
+            end
+          end
+        end
 
         def install!
           path = download_path

--- a/libraries/provider_divvy_app_windows.rb
+++ b/libraries/provider_divvy_app_windows.rb
@@ -36,10 +36,6 @@ class Chef
         def start!
           exe = ::File.join(PATH, 'Divvy.exe')
           execute 'run divvy' do
-            # TODO: This command succeeds when Chef is run locally, but Divvy
-            # exits immediately when run remotely from Test Kitchen. Probably
-            # something related to Windows session management that I'll need to
-            # learn more about. :(
             command "powershell -c \"Start-Process '#{exe}'\""
             action :run
             only_if do
@@ -51,12 +47,21 @@ class Chef
         end
 
         def install!
+          download_package
+          install_package
+        end
+
+        def download_package
           path = download_path
           remote_file path do
             source URL
             action :create
             only_if { !::File.exist?(PATH) }
           end
+        end
+
+        def install_package
+          path = download_path
           windows_package 'Divvy' do
             source path
             installer_type :nsis

--- a/libraries/provider_divvy_app_windows.rb
+++ b/libraries/provider_divvy_app_windows.rb
@@ -55,6 +55,7 @@ class Chef
           remote_file path do
             source URL
             action :create
+            only_if { !::File.exist?(PATH) }
           end
           windows_package 'Divvy' do
             source path

--- a/libraries/provider_mapping.rb
+++ b/libraries/provider_mapping.rb
@@ -25,3 +25,6 @@ require_relative 'provider_divvy_app'
 Chef::Platform.set(platform: :mac_os_x,
                    resource: :divvy_app,
                    provider: Chef::Provider::DivvyApp::MacOsX::AppStore)
+Chef::Platform.set(platform: :windows,
+                   resource: :divvy_app,
+                   provider: Chef::Provider::DivvyApp::Windows)

--- a/libraries/resource_divvy_app.rb
+++ b/libraries/resource_divvy_app.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+require 'chef/resource/lwrp_base'
+
 class Chef
   class Resource
     # A Chef resource for the Divvy app.
@@ -25,8 +27,8 @@ class Chef
     # @author Jonathan Hartman <j@p4nt5.com>
     class DivvyApp < Resource::LWRPBase
       self.resource_name = :divvy_app
-      actions :install
-      default_action :install
+      actions :install, :run
+      default_action [:install, :run]
 
       #
       # Attribute for the app's installed status.
@@ -35,6 +37,14 @@ class Chef
                 kind_of: [NilClass, TrueClass, FalseClass],
                 default: nil
       alias_method :installed?, :installed
+
+      #
+      # Attribute for the app's running status.
+      #
+      attribute :running,
+                kind_of: [NilClass, TrueClass, FalseClass],
+                default: nil
+      alias_method :running?, :running
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,8 @@ long_description 'Installs/Configures Divvy'
 version          '0.1.1'
 
 depends          'mac-app-store', '~> 0.1'
+depends          'windows', '~> 1.36'
 
 supports         'mac_os_x'
+supports         'windows'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-include_recipe 'mac-app-store'
+include_recipe 'mac-app-store' if node['platform'] == 'mac_os_x'
 
 divvy_app 'default' do
   action :install

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,5 +21,5 @@
 include_recipe 'mac-app-store' if node['platform'] == 'mac_os_x'
 
 divvy_app 'default' do
-  action :install
+  action [:install, :run]
 end

--- a/spec/libraries/provider_divvy_app_mac_os_x_app_store_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_app_store_spec.rb
@@ -9,6 +9,10 @@ describe Chef::Provider::DivvyApp::MacOsX::AppStore do
   let(:provider) { described_class.new(new_resource, nil) }
 
   describe '#install!' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:authorize_app!)
+    end
+
     it 'installs the app from the App Store' do
       p = provider
       expect(p).to receive(:mac_app_store_app).with('Divvy - Window Manager')
@@ -16,6 +20,12 @@ describe Chef::Provider::DivvyApp::MacOsX::AppStore do
       expect(p).to receive(:bundle_id).with('com.mizage.divvy')
       expect(p).to receive(:action).with(:install)
       p.send(:install!)
+    end
+  end
+
+  describe '#app_id' do
+    it 'returns the ID for an App Store install' do
+      expect(provider.send(:app_id)).to eq('com.mizage.Divvy')
     end
   end
 end

--- a/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
@@ -1,0 +1,46 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+require_relative '../../libraries/provider_divvy_app_mac_os_x_direct'
+
+describe Chef::Provider::DivvyApp::MacOsX::Direct do
+  let(:name) { 'Some App' }
+  let(:new_resource) { Chef::Resource::DivvyApp.new(name, nil) }
+  let(:provider) { described_class.new(new_resource, nil) }
+
+  describe '#install!' do
+    before(:each) do
+      [:execute, :remote_file].each do |m|
+        allow_any_instance_of(described_class).to receive(m)
+      end
+      allow_any_instance_of(described_class).to receive(:download_path)
+        .and_return('/tmp/Divvy.zip')
+    end
+
+    it 'sets up an unzipper execute resource' do
+      p = provider
+      expect(p).to receive(:execute).with('unzip divvy').and_yield
+      expect(p).to receive(:command)
+        .with('unzip -d /Applications /tmp/Divvy.zip')
+      expect(p).to receive(:action).with(:nothing)
+      p.send(:install!)
+    end
+
+    it 'downloads the file' do
+      p = provider
+      expect(p).to receive(:remote_file).with('/tmp/Divvy.zip').and_yield
+      expect(p).to receive(:source)
+        .with('http://mizage.com/downloads/Divvy.zip')
+      expect(p).to receive(:action).with(:create)
+      expect(p).to receive(:notifies).with(:run, 'execute[unzip divvy]')
+      p.send(:install!)
+    end
+  end
+
+  describe '#download_path' do
+    it 'returns the correct path' do
+      expected = "#{Chef::Config[:file_cache_path]}/Divvy.zip"
+      expect(provider.send(:download_path)).to eq(expected)
+    end
+  end
+end

--- a/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
@@ -37,7 +37,8 @@ describe Chef::Provider::DivvyApp::MacOsX::Direct do
       expect(p).to receive(:execute).with('unzip divvy').and_yield
       expect(p).to receive(:command)
         .with('unzip -d /Applications /tmp/Divvy.zip')
-      expect(p).to receive(:action).with(:nothing)
+      expect(p).to receive(:action).with(:run)
+      expect(p).to receive(:creates).with('/Applications/Divvy.app')
       p.send(:execute_resource)
     end
   end
@@ -54,7 +55,8 @@ describe Chef::Provider::DivvyApp::MacOsX::Direct do
       expect(p).to receive(:source)
         .with('http://mizage.com/downloads/Divvy.zip')
       expect(p).to receive(:action).with(:create)
-      expect(p).to receive(:notifies).with(:run, 'execute[unzip divvy]')
+      expect(p).to receive(:only_if).and_yield
+      expect(File).to receive(:exist?).with('/Applications/Divvy.app')
       p.send(:remote_file_resource)
     end
   end

--- a/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
@@ -10,36 +10,19 @@ describe Chef::Provider::DivvyApp::MacOsX::Direct do
 
   describe '#install!' do
     before(:each) do
-      [:execute_resource, :remote_file_resource, :authorize_app!].each do |m|
+      [:remote_file_resource, :execute_resource, :authorize_app!].each do |m|
         allow_any_instance_of(described_class).to receive(m)
       end
-    end
-
-    it 'sets up the execute resource' do
-      expect_any_instance_of(described_class).to receive(:execute_resource)
-      provider.send(:install!)
     end
 
     it 'sets up the remote file resource' do
       expect_any_instance_of(described_class).to receive(:remote_file_resource)
       provider.send(:install!)
     end
-  end
 
-  describe '#execute_resource' do
-    before(:each) do
-      allow_any_instance_of(described_class).to receive(:download_path)
-        .and_return('/tmp/Divvy.zip')
-    end
-
-    it 'sets up an unzipper execute resource' do
-      p = provider
-      expect(p).to receive(:execute).with('unzip divvy').and_yield
-      expect(p).to receive(:command)
-        .with('unzip -d /Applications /tmp/Divvy.zip')
-      expect(p).to receive(:action).with(:run)
-      expect(p).to receive(:creates).with('/Applications/Divvy.app')
-      p.send(:execute_resource)
+    it 'sets up the execute resource' do
+      expect_any_instance_of(described_class).to receive(:execute_resource)
+      provider.send(:install!)
     end
   end
 
@@ -58,6 +41,23 @@ describe Chef::Provider::DivvyApp::MacOsX::Direct do
       expect(p).to receive(:only_if).and_yield
       expect(File).to receive(:exist?).with('/Applications/Divvy.app')
       p.send(:remote_file_resource)
+    end
+  end
+
+  describe '#execute_resource' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:download_path)
+        .and_return('/tmp/Divvy.zip')
+    end
+
+    it 'sets up an unzipper execute resource' do
+      p = provider
+      expect(p).to receive(:execute).with('unzip divvy').and_yield
+      expect(p).to receive(:command)
+        .with('unzip -d /Applications /tmp/Divvy.zip')
+      expect(p).to receive(:action).with(:run)
+      expect(p).to receive(:creates).with('/Applications/Divvy.app')
+      p.send(:execute_resource)
     end
   end
 

--- a/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_direct_spec.rb
@@ -10,23 +10,23 @@ describe Chef::Provider::DivvyApp::MacOsX::Direct do
 
   describe '#install!' do
     before(:each) do
-      [:remote_file_resource, :execute_resource, :authorize_app!].each do |m|
+      [:download_package, :install_package, :authorize_app!].each do |m|
         allow_any_instance_of(described_class).to receive(m)
       end
     end
 
     it 'sets up the remote file resource' do
-      expect_any_instance_of(described_class).to receive(:remote_file_resource)
+      expect_any_instance_of(described_class).to receive(:download_package)
       provider.send(:install!)
     end
 
     it 'sets up the execute resource' do
-      expect_any_instance_of(described_class).to receive(:execute_resource)
+      expect_any_instance_of(described_class).to receive(:install_package)
       provider.send(:install!)
     end
   end
 
-  describe '#remote_file_resource' do
+  describe '#download_package' do
     before(:each) do
       allow_any_instance_of(described_class).to receive(:download_path)
         .and_return('/tmp/Divvy.zip')
@@ -40,11 +40,11 @@ describe Chef::Provider::DivvyApp::MacOsX::Direct do
       expect(p).to receive(:action).with(:create)
       expect(p).to receive(:only_if).and_yield
       expect(File).to receive(:exist?).with('/Applications/Divvy.app')
-      p.send(:remote_file_resource)
+      p.send(:download_package)
     end
   end
 
-  describe '#execute_resource' do
+  describe '#install_package' do
     before(:each) do
       allow_any_instance_of(described_class).to receive(:download_path)
         .and_return('/tmp/Divvy.zip')
@@ -57,7 +57,7 @@ describe Chef::Provider::DivvyApp::MacOsX::Direct do
         .with('unzip -d /Applications /tmp/Divvy.zip')
       expect(p).to receive(:action).with(:run)
       expect(p).to receive(:creates).with('/Applications/Divvy.app')
-      p.send(:execute_resource)
+      p.send(:install_package)
     end
   end
 

--- a/spec/libraries/provider_divvy_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_spec.rb
@@ -8,6 +8,25 @@ describe Chef::Provider::DivvyApp::MacOsX do
   let(:new_resource) { Chef::Resource::DivvyApp.new(name, nil) }
   let(:provider) { described_class.new(new_resource, nil) }
 
+  describe '#start!' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:execute)
+    end
+
+    it 'starts up Divvy for OS X' do
+      p = provider
+      expect(p).to receive(:execute).with('start divvy').and_yield
+      expect(p).to receive(:command).with('open /Applications/Divvy.app')
+      expect(p).to receive(:user).with(Etc.getlogin)
+      expect(p).to receive(:action).with(:run)
+      expect(p).to receive(:only_if).and_yield
+      cmd = 'ps -A -c -o command | grep ^Divvy$'
+      expect(Mixlib::ShellOut).to receive(:new).with(cmd)
+        .and_return(double(run_command: double(stdout: 'test')))
+      p.send(:start!)
+    end
+  end
+
   describe '#install!' do
     before(:each) do
       allow_any_instance_of(described_class).to receive(:authorize_app!)

--- a/spec/libraries/provider_divvy_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_spec.rb
@@ -9,8 +9,35 @@ describe Chef::Provider::DivvyApp::MacOsX do
   let(:provider) { described_class.new(new_resource, nil) }
 
   describe '#install!' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:authorize_app!)
+    end
+
+    it 'authorizes the Divvy app' do
+      expect_any_instance_of(described_class).to receive(:authorize_app!)
+      provider.send(:install!)
+    end
+  end
+
+  describe '#authorize_app!' do
+    before(:each) do
+      allow_any_instance_of(described_class)
+        .to receive(:mac_app_store_trusted_app)
+      allow_any_instance_of(described_class).to receive(:app_id)
+        .and_return('a.b.c')
+    end
+
+    it 'grants Accessibility access to the app' do
+      p = provider
+      expect(p).to receive(:mac_app_store_trusted_app).with('a.b.c').and_yield
+      expect(p).to receive(:action).with(:create)
+      p.send(:authorize_app!)
+    end
+  end
+
+  describe '#app_id' do
     it 'raises an error' do
-      expect { provider.send(:install!) }.to raise_error(NotImplementedError)
+      expect { provider.send(:app_id) }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/libraries/provider_divvy_app_spec.rb
+++ b/spec/libraries/provider_divvy_app_spec.rb
@@ -31,6 +31,29 @@ describe Chef::Provider::DivvyApp do
     end
   end
 
+  describe '#action_run' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:start!)
+    end
+
+    it 'calls the child `start!` method' do
+      expect_any_instance_of(described_class).to receive(:start!)
+      provider.action_run
+    end
+
+    it 'sets the resource running status' do
+      p = provider
+      p.action_run
+      expect(p.new_resource.running?).to eq(true)
+    end
+  end
+
+  describe '#start!' do
+    it 'raises an error' do
+      expect { provider.send(:start!) }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#install!' do
     it 'raises an error' do
       expect { provider.send(:install!) }.to raise_error(NotImplementedError)

--- a/spec/libraries/provider_divvy_app_windows_spec.rb
+++ b/spec/libraries/provider_divvy_app_windows_spec.rb
@@ -31,9 +31,25 @@ describe Chef::Provider::DivvyApp::Windows do
 
   describe '#install!' do
     before(:each) do
-      [:windows_package, :remote_file].each do |m|
+      [:download_package, :install_package].each do |m|
         allow_any_instance_of(described_class).to receive(m)
       end
+    end
+
+    it 'downloads the package' do
+      expect_any_instance_of(described_class).to receive(:download_package)
+      provider.send(:install!)
+    end
+
+    it 'installs the package' do
+      expect_any_instance_of(described_class).to receive(:install_package)
+      provider.send(:install!)
+    end
+  end
+
+  describe '#download_package' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:remote_file)
       allow_any_instance_of(described_class).to receive(:download_path)
         .and_return('/tmp/Divvy.exe')
     end
@@ -46,7 +62,15 @@ describe Chef::Provider::DivvyApp::Windows do
       expect(p).to receive(:action).with(:create)
       expect(p).to receive(:only_if).and_yield
       expect(File).to receive(:exist?).with(described_class::PATH)
-      p.send(:install!)
+      p.send(:download_package)
+    end
+  end
+
+  describe '#install_package' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:windows_package)
+      allow_any_instance_of(described_class).to receive(:download_path)
+        .and_return('/tmp/Divvy.exe')
     end
 
     it 'runs the installer' do
@@ -55,7 +79,7 @@ describe Chef::Provider::DivvyApp::Windows do
       expect(p).to receive(:source).with('/tmp/Divvy.exe')
       expect(p).to receive(:installer_type).with(:nsis)
       expect(p).to receive(:action).with(:install)
-      p.send(:install!)
+      p.send(:install_package)
     end
   end
 

--- a/spec/libraries/provider_divvy_app_windows_spec.rb
+++ b/spec/libraries/provider_divvy_app_windows_spec.rb
@@ -44,6 +44,8 @@ describe Chef::Provider::DivvyApp::Windows do
       expect(p).to receive(:source)
         .with('http://mizage.com/downloads/InstallDivvy.exe')
       expect(p).to receive(:action).with(:create)
+      expect(p).to receive(:only_if).and_yield
+      expect(File).to receive(:exist?).with(described_class::PATH)
       p.send(:install!)
     end
 

--- a/spec/libraries/provider_divvy_app_windows_spec.rb
+++ b/spec/libraries/provider_divvy_app_windows_spec.rb
@@ -1,0 +1,45 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+require_relative '../../libraries/provider_divvy_app_windows'
+
+describe Chef::Provider::DivvyApp::Windows do
+  let(:name) { 'Some App' }
+  let(:new_resource) { Chef::Resource::DivvyApp.new(name, nil) }
+  let(:provider) { described_class.new(new_resource, nil) }
+
+  describe '#install!' do
+    before(:each) do
+      [:windows_package, :remote_file].each do |m|
+        allow_any_instance_of(described_class).to receive(m)
+      end
+      allow_any_instance_of(described_class).to receive(:download_path)
+        .and_return('/tmp/Divvy.exe')
+    end
+
+    it 'downloads the file' do
+      p = provider
+      expect(p).to receive(:remote_file).with('/tmp/Divvy.exe').and_yield
+      expect(p).to receive(:source)
+        .with('http://mizage.com/downloads/InstallDivvy.exe')
+      expect(p).to receive(:action).with(:create)
+      p.send(:install!)
+    end
+
+    it 'runs the installer' do
+      p = provider
+      expect(p).to receive(:windows_package).with('Divvy').and_yield
+      expect(p).to receive(:source).with('/tmp/Divvy.exe')
+      expect(p).to receive(:installer_type).with(:nsis)
+      expect(p).to receive(:action).with(:install)
+      p.send(:install!)
+    end
+  end
+
+  describe '#download_path' do
+    it 'returns the correct path' do
+      expected = "#{Chef::Config[:file_cache_path]}/InstallDivvy.exe"
+      expect(provider.send(:download_path)).to eq(expected)
+    end
+  end
+end

--- a/spec/libraries/provider_mapping_spec.rb
+++ b/spec/libraries/provider_mapping_spec.rb
@@ -17,6 +17,14 @@ describe :provider_mapping do
     end
   end
 
+  context 'Windows' do
+    let(:platform) { :windows }
+
+    it 'uses the Windows Divvy app provider' do
+      expect(app_provider).to eq(Chef::Provider::DivvyApp::Windows)
+    end
+  end
+
   context 'Ubuntu' do
     let(:platform) { :ubuntu }
 

--- a/spec/libraries/resource_divvy_app_spec.rb
+++ b/spec/libraries/resource_divvy_app_spec.rb
@@ -13,8 +13,22 @@ describe Chef::Resource::DivvyApp do
       expect(resource.instance_variable_get(:@resource_name)).to eq(exp)
     end
 
+    it 'sets the correct supported actions' do
+      expected = [:nothing, :install, :run]
+      expect(resource.instance_variable_get(:@allowed_actions)).to eq(expected)
+    end
+
+    it 'sets the correct default action' do
+      expected = [:install, :run]
+      expect(resource.instance_variable_get(:@action)).to eq(expected)
+    end
+
     it 'sets the installed status to nil' do
       expect(resource.instance_variable_get(:@installed)).to eq(nil)
+    end
+
+    it 'sets the running status to nil' do
+      expect(resource.instance_variable_get(:@running)).to eq(nil)
     end
   end
 
@@ -42,6 +56,40 @@ describe Chef::Resource::DivvyApp do
         let(:resource) do
           r = super()
           r.instance_variable_set(:@installed, false)
+          r
+        end
+
+        it 'returns true' do
+          expect(resource.send(m)).to eq(false)
+        end
+      end
+    end
+  end
+
+  [:running, :running?].each do |m|
+    describe "##{m}" do
+      context 'default unknown running status' do
+        it 'returns nil' do
+          expect(resource.send(m)).to eq(nil)
+        end
+      end
+
+      context 'app running' do
+        let(:resource) do
+          r = super()
+          r.instance_variable_set(:@running, true)
+          r
+        end
+
+        it 'returns true' do
+          expect(resource.send(m)).to eq(true)
+        end
+      end
+
+      context 'app not running' do
+        let(:resource) do
+          r = super()
+          r.instance_variable_set(:@running, false)
           r
         end
 

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -11,6 +11,10 @@ describe 'divvy::default' do
     it 'installs the Divvy app' do
       expect(chef_run).to install_divvy_app('default')
     end
+
+    it 'runs the Divvy app' do
+      expect(chef_run).to run_divvy_app('default')
+    end
   end
 
   context 'Mac OS X platform' do

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -7,15 +7,29 @@ describe 'divvy::default' do
   let(:runner) { ChefSpec::SoloRunner.new(platform) }
   let(:chef_run) { runner.converge(described_recipe) }
 
+  shared_examples_for 'any platform' do
+    it 'installs the Divvy app' do
+      expect(chef_run).to install_divvy_app('default')
+    end
+  end
+
   context 'Mac OS X platform' do
     let(:platform) { { platform: 'mac_os_x', version: '10.10' } }
+
+    it_behaves_like 'any platform'
 
     it 'runs the mac-app-store default recipe' do
       expect(chef_run).to include_recipe('mac-app-store')
     end
+  end
 
-    it 'installs the Divvy app' do
-      expect(chef_run).to install_divvy_app('default')
+  context 'Windows 2012 platform' do
+    let(:platform) { { platform: 'windows', version: '2012R2' } }
+
+    it_behaves_like 'any platform'
+
+    it 'does not run the mac-app-store recipe' do
+      expect(chef_run).not_to include_recipe('mac-app-store')
     end
   end
 end

--- a/test/fixtures/cookbooks/divvy_test/CHANGELOG.md
+++ b/test/fixtures/cookbooks/divvy_test/CHANGELOG.md
@@ -1,0 +1,6 @@
+Divvy_test Cookbook CHANGELOG
+=============================
+
+v0.0.1 (2015-04-29)
+-------------------
+- Development started

--- a/test/fixtures/cookbooks/divvy_test/README.md
+++ b/test/fixtures/cookbooks/divvy_test/README.md
@@ -1,0 +1,3 @@
+Divvy_test Cookbook
+===================
+A test wrapper for the Divvy cookbook.

--- a/test/fixtures/cookbooks/divvy_test/metadata.rb
+++ b/test/fixtures/cookbooks/divvy_test/metadata.rb
@@ -1,0 +1,15 @@
+# Encoding: UTF-8
+#
+# rubocop:disable SingleSpaceBeforeFirstArg
+name             'divvy_test'
+maintainer       'Jonathan Hartman'
+maintainer_email 'j@p4nt5.com'
+license          'apache2'
+description      'Installs/Configures divvy_test'
+long_description 'Installs/Configures divvy_test'
+version          '0.0.1'
+
+depends          'divvy'
+
+supports         'mac_os_x'
+# rubocop:enable SingleSpaceBeforeFirstArg

--- a/test/fixtures/cookbooks/divvy_test/recipes/mac_direct_download.rb
+++ b/test/fixtures/cookbooks/divvy_test/recipes/mac_direct_download.rb
@@ -2,5 +2,4 @@
 
 divvy_app 'default' do
   provider Chef::Provider::DivvyApp::MacOsX::Direct
-  action :install
 end

--- a/test/fixtures/cookbooks/divvy_test/recipes/mac_direct_download.rb
+++ b/test/fixtures/cookbooks/divvy_test/recipes/mac_direct_download.rb
@@ -1,0 +1,6 @@
+# Encoding: UTF-8
+
+divvy_app 'default' do
+  provider Chef::Provider::DivvyApp::MacOsX::Direct
+  action :install
+end

--- a/test/integration/default/serverspec/localhost/app_spec.rb
+++ b/test/integration/default/serverspec/localhost/app_spec.rb
@@ -3,13 +3,35 @@
 require_relative '../spec_helper'
 
 describe 'Divvy app' do
-  describe package('com.mizage.Divvy') do
+  describe package('com.mizage.Divvy'), if: os[:family] == 'darwin' do
     it 'is installed' do
       expect(subject).to be_installed.by(:pkgutil)
     end
   end
 
-  describe file('/Applications/Divvy.app') do
+  describe file('/Applications/Divvy.app'), if: os[:family] == 'darwin' do
+    it 'is present on the filesystem' do
+      expect(subject).to be_directory
+    end
+  end
+
+  describe package('Divvy'), if: os[:family] == 'windows' do
+    it 'is installed' do
+      pending 'SpecInfra ability to search HKCU registry keys'
+      expect(subject).to be_installed
+    end
+  end
+
+  # TODO: This test can go away when the one above is no longer pending
+  describe command("(Get-ItemProperty 'HKCU:\\Software\\Microsoft\\Windows\\" \
+                   "CurrentVersion\\Uninstall\\Divvy')") do
+    it 'indicates Divvy is installed' do
+      expect(subject.stdout).to match(/DisplayName +: +Divvy/)
+    end
+  end
+
+  describe file(File.expand_path('~/AppData/Local/Mizage LLC/Divvy')),
+           if: os[:family] == 'windows' do
     it 'is present on the filesystem' do
       expect(subject).to be_directory
     end

--- a/test/integration/default/serverspec/localhost/app_spec.rb
+++ b/test/integration/default/serverspec/localhost/app_spec.rb
@@ -27,4 +27,18 @@ describe 'Divvy app' do
       expect(subject).to be_directory
     end
   end
+
+  # TODO: This should pass in Windows too, but Specinfra throws a
+  # NotImplementedError.
+  describe process('Divvy'), if: os[:family] == 'darwin' do
+    it 'is running' do
+      expect(subject).to be_running
+    end
+  end
+
+  describe command('Get-Process Divvy'), if: os[:family] == 'windows' do
+    it 'indicates Divvy is running' do
+      expect(subject.exit_status).to eq(0)
+    end
+  end
 end

--- a/test/integration/default/serverspec/localhost/app_spec.rb
+++ b/test/integration/default/serverspec/localhost/app_spec.rb
@@ -17,16 +17,7 @@ describe 'Divvy app' do
 
   describe package('Divvy'), if: os[:family] == 'windows' do
     it 'is installed' do
-      pending 'SpecInfra ability to search HKCU registry keys'
       expect(subject).to be_installed
-    end
-  end
-
-  # TODO: This test can go away when the one above is no longer pending
-  describe command("(Get-ItemProperty 'HKCU:\\Software\\Microsoft\\Windows\\" \
-                   "CurrentVersion\\Uninstall\\Divvy')") do
-    it 'indicates Divvy is installed' do
-      expect(subject.stdout).to match(/DisplayName +: +Divvy/)
     end
   end
 

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -2,4 +2,9 @@
 
 require 'serverspec'
 
-set :backend, :exec
+if RUBY_PLATFORM.match(/mswin|mingw32|windows/)
+  set :os, family: 'windows'
+  set :backend, :cmd
+else
+  set :backend, :exec
+end

--- a/test/integration/mac_direct_download/serverspec/localhost/app_spec.rb
+++ b/test/integration/mac_direct_download/serverspec/localhost/app_spec.rb
@@ -1,0 +1,11 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'Divvy app' do
+  describe file('/Applications/Divvy.app') do
+    it 'is present on the filesystem' do
+      expect(subject).to be_directory
+    end
+  end
+end

--- a/test/integration/mac_direct_download/serverspec/localhost/app_spec.rb
+++ b/test/integration/mac_direct_download/serverspec/localhost/app_spec.rb
@@ -8,4 +8,10 @@ describe 'Divvy app' do
       expect(subject).to be_directory
     end
   end
+
+  describe process('Divvy') do
+    it 'is running' do
+      expect(subject).to be_running
+    end
+  end
 end

--- a/test/integration/mac_direct_download/serverspec/spec_helper.rb
+++ b/test/integration/mac_direct_download/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+# Encoding: UTF-8
+
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
- [x] Support direct downloads in OS X (#2)
- [x] Support Windows (#1)
- [x] Grant Accessibility privileges in OS X (#5)
- [x] Print a license reminder to the info log
- [x] Run the app after installing (except for Windows under TK)
