### PR TITLE
Use macosx_accessibility instead of mac_app_store_trusted_app

### DIFF
--- a/libraries/provider_divvy_app_mac_os_x.rb
+++ b/libraries/provider_divvy_app_mac_os_x.rb
@@ -19,6 +19,7 @@
 #
 
 require 'etc'
+require 'chef/dsl/include_recipe'
 require 'chef/provider/lwrp_base'
 require_relative 'provider_divvy_app'
 require_relative 'provider_divvy_app_mac_os_x_app_store'
@@ -64,8 +65,10 @@ class Chef
         # Declare a trusted_app resource and grant Accessibility to the app.
         #
         def authorize_app!
-          mac_app_store_trusted_app app_id do
-            action :create
+          ai = app_id
+          macosx_accessibility ai do
+            items [ai]
+            action [:insert, :enable]
           end
         end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ long_description 'Installs/Configures Divvy'
 version          '0.1.1'
 
 depends          'mac-app-store', '~> 0.1'
+depends          'macosx_accessibility', '~> 0.1'
 depends          'windows', '~> 1.36'
 
 supports         'mac_os_x'

--- a/spec/libraries/provider_divvy_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_divvy_app_mac_os_x_spec.rb
@@ -41,15 +41,16 @@ describe Chef::Provider::DivvyApp::MacOsX do
   describe '#authorize_app!' do
     before(:each) do
       allow_any_instance_of(described_class)
-        .to receive(:mac_app_store_trusted_app)
+        .to receive(:macosx_accessibility)
       allow_any_instance_of(described_class).to receive(:app_id)
         .and_return('a.b.c')
     end
 
     it 'grants Accessibility access to the app' do
       p = provider
-      expect(p).to receive(:mac_app_store_trusted_app).with('a.b.c').and_yield
-      expect(p).to receive(:action).with(:create)
+      expect(p).to receive(:macosx_accessibility).with('a.b.c').and_yield
+      expect(p).to receive(:items).with(%w(a.b.c))
+      expect(p).to receive(:action).with([:insert, :enable])
       p.send(:authorize_app!)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,9 @@ require 'tmpdir'
 require 'fileutils'
 require_relative '../libraries/matchers'
 require_relative 'support/resource/mac_app_store_app'
+require_relative 'support/resource/macosx_accessibility'
 require_relative 'support/provider/mac_app_store_app'
+require_relative 'support/provider/macosx_accessibility'
 
 RSpec.configure do |c|
   c.color = true

--- a/spec/support/provider/macosx_accessibility.rb
+++ b/spec/support/provider/macosx_accessibility.rb
@@ -1,0 +1,13 @@
+# Encoding: UTF-8
+
+require_relative '../../spec_helper'
+
+class Chef
+  class Provider
+    # A fake macosx_accessibility provider
+    #
+    # @author Jonathan Hartman <j@p4nt5.com>
+    class MacosxAccessibility < Provider::LWRPBase
+    end
+  end
+end

--- a/spec/support/resource/macosx_accessibility.rb
+++ b/spec/support/resource/macosx_accessibility.rb
@@ -1,0 +1,17 @@
+# Encoding: UTF-8
+
+require_relative '../../spec_helper'
+
+class Chef
+  class Resource
+    # A fake macosx_accessibility resource
+    #
+    # @author Jonathan Hartman <j@p4nt5.com>
+    class MacosxAccessibility < Resource::LWRPBase
+      self.resource_name = :macosx_accessibility
+      actions :insert, :enable
+      default_action :insert
+      attribute :items, kind_of: Array
+    end
+  end
+end


### PR DESCRIPTION
The trusted_app resource is hacky and shouldn't be reused by other cookbooks.
