### PR TITLE
Make :enable use user-level registry keys

### DIFF
--- a/libraries/provider_divvy_app_windows.rb
+++ b/libraries/provider_divvy_app_windows.rb
@@ -38,8 +38,13 @@ class Chef
         #
         def enable!
           exe = ::File.join(PATH, 'Divvy.exe').gsub('/', '\\')
-          windows_auto_run 'Divvy' do
-            program exe
+          reg = 'HKCU\Software\Microsoft\Windows\CurrentVersion\Run'
+          windows_registry reg do
+            values('WinDivvy' => "\"#{exe}\" -background")
+            action :create
+          end
+          windows_registry 'HKCU\Software\Mizage LLC\Divvy' do
+            values('auto_start' => 'true')
             action :create
           end
         end

--- a/spec/libraries/provider_divvy_app_windows_spec.rb
+++ b/spec/libraries/provider_divvy_app_windows_spec.rb
@@ -17,8 +17,15 @@ describe Chef::Provider::DivvyApp::Windows do
       p = provider
       allow(File).to receive(:join).with(described_class::PATH, 'Divvy.exe')
         .and_return('c:/divvy/Divvy.exe')
-      expect(p).to receive(:windows_auto_run).with('Divvy').and_yield
-      expect(p).to receive(:program).with('c:\divvy\Divvy.exe')
+      expect(p).to receive(:windows_registry)
+        .with('HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run')
+        .and_yield
+      expect(p).to receive(:values)
+        .with('WinDivvy' => '"c:\divvy\Divvy.exe" -background')
+      expect(p).to receive(:action).with(:create)
+      expect(p).to receive(:windows_registry)
+        .with('HKCU\\Software\\Mizage LLC\\Divvy').and_yield
+      expect(p).to receive(:values).with('auto_start' => 'true')
       expect(p).to receive(:action).with(:create)
       p.send(:enable!)
     end

--- a/test/integration/default/serverspec/localhost/app_spec.rb
+++ b/test/integration/default/serverspec/localhost/app_spec.rb
@@ -38,10 +38,10 @@ describe 'Divvy app' do
   end
 
   describe command(
-    'Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"'
+    'Get-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"'
   ), if: os[:family] == 'windows' do
     it 'indicates Divvy is enabled' do
-      expect(subject.stdout).to match(/^Divvy +:/)
+      expect(subject.stdout).to match(/^WinDivvy +:/)
     end
   end
 


### PR DESCRIPTION
This makes it match the registry modifications done when you click "Start Divvy at login" in its UI in Windows.
