### PR TITLE
Prep for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ It offers recipe-based and resource-based installs. A resource-based install
 from the Mac App Store requires an already-open instance of the `mac_app_store`
 resource.
 
+On either supported platform, a user must be signed in for the install to
+complete successfully.
+
 Usage
 =====
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,8 +9,8 @@ description      'Installs/Configures Divvy'
 long_description 'Installs/Configures Divvy'
 version          '0.1.1'
 
-depends          'mac-app-store', '~> 0.1'
-depends          'macosx_accessibility', '~> 0.1'
+depends          'mac-app-store', '~> 1.0'
+depends          'macosx_accessibility', '~> 1.0'
 depends          'windows', '~> 1.36'
 
 supports         'mac_os_x'


### PR DESCRIPTION
Once the 1.0 mac-app-store release is deployed, this can be merged and released.
